### PR TITLE
Make HgStatusCacheTimeExpiry configurable to fix latency issues

### DIFF
--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -159,7 +159,7 @@ let s:HgStatusCacheTime = 0
 let s:HgStatusCacheDirty = 0
 function! g:NERDTreeGetHgStatusPrefix(path)
     if s:HgStatusCacheDirty || (g:NERDTreeHgStatusCacheTimeExpiry > 0 
-            \ && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
+            \ && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry)
         let s:HgStatusCacheTime = localtime()
         call g:NERDTreeHgStatusRefresh()
     endif

--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -156,7 +156,7 @@ endfunction
 " Args: path
 let s:HgStatusCacheTime = 0
 function! g:NERDTreeGetHgStatusPrefix(path)
-    if NERDTreeHgStatusCacheTimeExpiry > 0 && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
+    if g:NERDTreeHgStatusCacheTimeExpiry > 0 && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
         let s:HgStatusCacheTime = localtime()
         call g:NERDTreeHgStatusRefresh()
     endif

--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -81,6 +81,7 @@ function! g:NERDTreeHgStatusRefresh()
     "call Dfunc("NERDTreeHgStatusRefresh()")
     let b:NERDTreeCachedHgFileStatus = {}
     let b:NERDTreeCachedHgDirtyDir   = {}
+    let s:HgStatusCacheDirty = 0
     let b:NOT_A_HG_REPOSITORY        = 1
 
     let l:root = b:NERDTreeRoot.path.str()
@@ -155,8 +156,10 @@ endfunction
 " return the indicator of the path
 " Args: path
 let s:HgStatusCacheTime = 0
+let s:HgStatusCacheDirty = 0
 function! g:NERDTreeGetHgStatusPrefix(path)
-    if g:NERDTreeHgStatusCacheTimeExpiry > 0 && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
+    if s:HgStatusCacheDirty || (g:NERDTreeHgStatusCacheTimeExpiry > 0 
+            \ && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
         let s:HgStatusCacheTime = localtime()
         call g:NERDTreeHgStatusRefresh()
     endif
@@ -271,7 +274,7 @@ function! s:CursorHoldUpdate()
     if !g:NERDTree.IsOpen()
         return
     endif
-
+    let s:HgStatusCacheDirty = 1
     let l:winnr = winnr()
     call g:NERDTree.CursorToTreeWin()
     call b:NERDTreeRoot.refreshFlags()
@@ -303,6 +306,7 @@ function! s:FileUpdate(fname)
     if l:node == {}
         return
     endif
+    let s:HgStatusCacheDirty = 1
     call l:node.refreshFlags()
     let l:node = l:node.parent
     while !empty(l:node)

--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -38,6 +38,12 @@ if !exists('g:NERDTreeUpdateOnCursorHold')
     let g:NERDTreeUpdateOnCursorHold = 1
 endif
 
+" TTL for caching the HG status before refreshing it.
+" Set to 0 to avoid timed refreshes of the status cache.
+if !exists('g:NERDTreeHgStatusCacheTimeExpiry')
+    let g:NERDTreeHgStatusCacheTimeExpiry = 2
+endif
+
 if !exists('s:NERDTreeIndicatorMap')
     let s:NERDTreeIndicatorMap = {
                 \ 'Modified'  : '✹',
@@ -148,10 +154,9 @@ endfunction
 " FUNCTION: g:NERDTreeGetHgStatusPrefix(path) {{{1
 " return the indicator of the path
 " Args: path
-let s:HgStatusCacheTimeExpiry = 2
 let s:HgStatusCacheTime = 0
 function! g:NERDTreeGetHgStatusPrefix(path)
-    if localtime() - s:HgStatusCacheTime > s:HgStatusCacheTimeExpiry
+    if NERDTreeHgStatusCacheTimeExpiry > 0 && localtime() > s:HgStatusCacheTime + g:NERDTreeHgStatusCacheTimeExpiry 
         let s:HgStatusCacheTime = localtime()
         call g:NERDTreeHgStatusRefresh()
     endif


### PR DESCRIPTION
By making NERDTreeHgStatusCacheTimeExpiry configurable via .vimrc, the user (me) can avoid latency hit when expanding folders, or disable this completely by setting it to 0.

Two seconds is way too low IMO by the way, the default should be at least 20 seconds. This create huge latency issues when I'm using the otherwise excellent plugin!

I've also added a variable to control when the status cache is dirty, thus forcing a refresh regardless of the timeout. After both those changes the plugin is much faster for me.