### PR TITLE
Fix slash issue for latest version of nerdtree

### DIFF
--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -184,7 +184,13 @@ endfunction
 
 function! s:NERDTreeGetIndicator(statusKey)
     if exists('g:NERDTreeIndicatorMapCustom')
+        " This is deprecated by nerdtree-git-plugin
         let l:indicator = get(g:NERDTreeIndicatorMapCustom, a:statusKey, '')
+        if l:indicator !=# ''
+            return l:indicator
+        endif
+    elseif exists('g:NERDTreeGitStatusIndicatorMapCustom')
+        let l:indicator = get(g:NERDTreeGitStatusIndicatorMapCustom, a:statusKey, '')
         if l:indicator !=# ''
             return l:indicator
         endif

--- a/nerdtree_plugin/hg_status.vim
+++ b/nerdtree_plugin/hg_status.vim
@@ -156,7 +156,7 @@ function! g:NERDTreeGetHgStatusPrefix(path)
         call g:NERDTreeHgStatusRefresh()
     endif
     let l:pathStr = a:path.str()
-    let l:cwd = b:NERDTreeRoot.path.str() . a:path.Slash()
+    let l:cwd = b:NERDTreeRoot.path.str() . nerdtree#slash()
     if nerdtree#runningWindows()
         let l:pathStr = a:path.WinToUnixPath(l:pathStr)
         let l:cwd = a:path.WinToUnixPath(l:cwd)


### PR DESCRIPTION
Hi!

Just submitting a fix for this error when opening the latest version of nerdtree:
```
Error detected while processing function nerdtree#checkForBrowse[9]..212[2]..213[17]..214[8]..178[25]..17
6[15]..288[5]..NERDTreeHgStatusRefreshListener[9]..NERDTreeGetHgStatusPrefix:                            
line    8:                                                                                               
E716: Key not present in Dictionary: Slash()                                                             
Error detected while processing function nerdtree#checkForBrowse[9]..212[2]..213[17]..214[8]..178:       
line   25:                                                                                               
E171: Missing :endif                                                                                     
```

Change is mirrored from the git plugin: https://github.com/Xuyuanp/nerdtree-git-plugin/commit/db33cfa4d3c066ee9e204f65cf13090b21978001